### PR TITLE
chore: silence pnpm 'Ignored build scripts' warning on Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,11 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.17",
     "typescript": "^5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@vercel/speed-insights",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Silences the `Ignored build scripts: @vercel/speed-insights@1.2.0, sharp@0.34.5` warning that's been showing up on every Vercel build (and locally).

## Why

pnpm 10+ blocks `postinstall` lifecycle scripts by default for transitive dependencies — supply-chain hardening to prevent arbitrary code from running during `pnpm install`. You explicitly opt packages in via `pnpm.onlyBuiltDependencies`.

- `sharp` powers Next.js image optimization. (On Vercel, Next bundles its own sharp at runtime so the warning was cosmetic — but tidier to have its postinstall run.)
- `@vercel/speed-insights` runs a small notice on install.

Both are first-party / well-known packages, safe to allow.

## Change

Four lines in `package.json`:

```json
"pnpm": {
  "onlyBuiltDependencies": [
    "@vercel/speed-insights",
    "sharp"
  ]
}
```

## Test plan

- [x] `pnpm install` runs without the warning
- [x] postinstall scripts execute (`@vercel/speed-insights postinstall: Done` in output)
- [ ] Next Vercel build log no longer shows the "Ignored build scripts" block
- [ ] CI green (typecheck, build, Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)