### PR TITLE
perf: prerender OG image at build time instead of edge runtime

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,6 +1,5 @@
 import { ImageResponse } from "next/og"
 
-export const runtime = "edge"
 export const alt = "Akshat Sahu — Software Engineer"
 export const size = { width: 1200, height: 630 }
 export const contentType = "image/png"


### PR DESCRIPTION
## Summary

Drops `export const runtime = "edge"` from `app/opengraph-image.tsx` so the Open Graph image is **prerendered to a static PNG at build time** instead of generated by an edge function on every share-link unfurl.

## Why

The OG image is identical for every visitor — same name, same gradient, same tagline, no per-request data flowing in. Running it as an edge function meant every time someone pasted your link in Slack/Twitter/iMessage/etc., Vercel spun up a function invocation to generate the same 1200×630 PNG over and over. With the warning silenced, you also get:

- 🚀 **Faster unfurls** — served as a plain CDN asset, no cold start, no compute time.
- 💸 **Zero edge-function invocations** for OG previews (counted against your Vercel quota otherwise).
- 🔇 **One fewer build warning** (`Using edge runtime on a page currently disables static generation for that page`).

## Build output diff

**Before**
```
Route (app)
┌ ○ /
├ ○ /_not-found
├ ƒ /opengraph-image     ← dynamic, runs on every request
├ ○ /robots.txt
└ ○ /sitemap.xml
```

**After**
```
Route (app)
┌ ○ /
├ ○ /_not-found
├ ○ /opengraph-image     ← static, served from CDN
├ ○ /robots.txt
└ ○ /sitemap.xml

○ (Static)  prerendered as static content
```

All 5 routes are now static. No more dynamic functions on this app.

## Trade-off

If you ever want to update the OG image text (e.g. tagline change), you need a new deploy — but you're already deploying on every commit anyway. Effectively zero downside.

## Test plan

- [x] `pnpm build` — clean, all routes static
- [x] No more `Using edge runtime ...` warning in build output
- [ ] CI green (typecheck, build, Playwright)
- [ ] After merge: paste production URL into Slack/Twitter, confirm OG image still loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)