### PR TITLE
fix(hero): show engineer.ts code card from lg: instead of xl:

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -71,16 +71,16 @@ export default function Hero() {
       <div className="absolute inset-0 bg-[radial-gradient(hsl(var(--border))_1px,transparent_1px)] [background-size:26px_26px] opacity-35 pointer-events-none" />
 
       <div className="relative z-10 w-full max-w-6xl mx-auto px-4 sm:px-6">
-        <div className="grid grid-cols-1 xl:grid-cols-[1fr_auto] gap-10 xl:gap-20 items-center">
+        <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-10 lg:gap-20 items-center">
 
           {/* Left: main content */}
-          <div className="text-center xl:text-left">
+          <div className="text-center lg:text-left">
             {/* Status pill */}
             <motion.div
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.5, delay: 0.1, ease }}
-              className="flex justify-center xl:justify-start"
+              className="flex justify-center lg:justify-start"
             >
               <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-primary/10 text-primary text-xs font-mono font-medium tracking-wide border border-primary/20">
                 <span className="relative flex h-2 w-2">
@@ -103,7 +103,7 @@ export default function Hero() {
 
             {/* Typewriter role — nowrap + min-h prevents the long word from wrapping or clipping */}
             <motion.div
-              className="mt-5 min-h-8 flex items-center justify-center xl:justify-start"
+              className="mt-5 min-h-8 flex items-center justify-center lg:justify-start"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.35, ease }}
@@ -118,7 +118,7 @@ export default function Hero() {
 
             {/* One-liner */}
             <motion.p
-              className="mt-4 text-[15px] text-muted-foreground max-w-md mx-auto xl:mx-0 leading-relaxed"
+              className="mt-4 text-[15px] text-muted-foreground max-w-md mx-auto lg:mx-0 leading-relaxed"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.45, ease }}
@@ -128,7 +128,7 @@ export default function Hero() {
 
             {/* Social links + Resume CTA */}
             <motion.div
-              className="mt-8 flex flex-wrap items-center justify-center xl:justify-start gap-3"
+              className="mt-8 flex flex-wrap items-center justify-center lg:justify-start gap-3"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.55, ease }}
@@ -165,9 +165,9 @@ export default function Hero() {
             </motion.div>
           </div>
 
-          {/* Right: decorative code card (xl+ only — needs the room) */}
+          {/* Right: decorative code card (lg+ — shows on most laptops including 14" with sidebar) */}
           <motion.div
-            className="hidden xl:block shrink-0"
+            className="hidden lg:block shrink-0"
             initial={{ opacity: 0, x: 20 }}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.7, delay: 0.4, ease }}


### PR DESCRIPTION
## Summary

Lowers the hero's responsive split-layout breakpoint from `xl:` (1280px) to `lg:` (1024px) so the decorative `engineer.ts` code card shows up on actual laptops — including a 14" MacBook with a browser sidebar open (Arc, Vivaldi, etc.) where the effective viewport can drop below 1280px even on a 1512px-wide screen.

## Why

`xl:` was too aggressive. A 14" MacBook is 1512px native, but with Arc's sidebar at ~300px the document viewport is ~1212px — below `xl:` (1280px) but well above `lg:` (1024px). Result: the user reported the card was hidden on their daily-driver machine.

`lg:` is the right call:
- Card visible on every laptop tier, even with sidebars
- iPad landscape (1024px) gets the card too
- iPad portrait (768px), phones still get the clean single-column layout

The earlier crowding concern at 1024-1280px was overblown — the headline still fits comfortably next to a 256px wide card with the existing fluid `clamp(2.75rem, 9vw, 5.5rem)` typography.

## Change

Seven coordinated `xl:` → `lg:` flips in `components/hero.tsx`:

```diff
- <div className="grid grid-cols-1 xl:grid-cols-[1fr_auto] gap-10 xl:gap-20 items-center">
+ <div className="grid grid-cols-1 lg:grid-cols-[1fr_auto] gap-10 lg:gap-20 items-center">

- <div className="text-center xl:text-left">
+ <div className="text-center lg:text-left">

- className="hidden xl:block shrink-0"
+ className="hidden lg:block shrink-0"
```

…and four more (status pill align, typewriter align, paragraph align, button-row align). All seven need to flip together to keep the layout consistent — hide the card without flipping the others and you'd get a single-column layout with left-aligned text, which looks broken.

## Test plan

- [x] `pnpm build` — clean, all 5 routes static
- [ ] CI green (typecheck, build, Playwright)
- [ ] On the user's 14" MacBook with normal browser/sidebar setup: code card visible on right of hero
- [ ] iPad portrait: still shows clean centered single-column hero (no card)
- [ ] iPhone: still shows clean centered single-column hero (no card)

🤖 Generated with [Claude Code](https://claude.com/claude-code)