### PR TITLE
feat: liquid glass theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -27,6 +27,23 @@
 
     --primary-rgb: 157 141 255;
     --accent-rgb: 111 201 164;
+
+    /* ─── Liquid Glass material — base knobs (the only values you tune) ─── */
+    --glass-fill-base: 0.55;   --glass-fill: var(--glass-fill-base);  /* card translucency */
+    --glass-hi-base:   0.55;   --glass-hi:   var(--glass-hi-base);    /* top-left diagonal sheen */
+    --glass-spec-base: 0.60;   --glass-spec: var(--glass-spec-base);  /* inset top specular line */
+    --glass-cast-base: 0.12;   --glass-cast: var(--glass-cast-base);  /* float / drop shadow */
+    --glass-sat:         180%;
+    --glass-blur:        18px;
+    --glass-blur-strong: 28px;
+    --glass-blur-thin:   10px;
+    --glass-edge-hi:     0.65;  /* bright top-left hairline */
+    --glass-edge-lo:     0.10;  /* dark bottom-right hairline */
+    --scrim-fill:        0.32;
+
+    /* ─── Ambient aurora field ─── */
+    --orb-1: 0.10;  --orb-2: 0.08;  --orb-3: 0.06;
+    --grain-opacity: 0.035;
   }
 
   .dark {
@@ -52,6 +69,20 @@
 
     --primary-rgb: 209 196 255;
     --accent-rgb: 120 218 174;
+
+    /* ─── Liquid Glass — dark overrides ─── */
+    --glass-fill-base: 0.42;   /* smokier: lets the vivid aurora through */
+    --glass-hi-base:   0.10;   /* white sheen must drop hard in dark or glass greys out */
+    --glass-spec-base: 0.14;   /* a lit rim, not a white line */
+    --glass-cast-base: 0.45;   /* depth comes from shadow in dark, not highlight */
+    --glass-sat:       160%;
+    --glass-blur:      20px;
+    --glass-edge-hi:   0.18;
+    --glass-edge-lo:   0.40;
+    --scrim-fill:      0.30;
+
+    --orb-1: 0.20;  --orb-2: 0.15;  --orb-3: 0.12;
+    --grain-opacity: 0.06;
   }
 }
 
@@ -97,6 +128,126 @@
   50%       { background-position: 100% 50%; }
 }
 
+/* ─── Ambient aurora field (one paint, fixed, zero backdrop-filter) ─── */
+
+@layer components {
+  .ambient-field {
+    position: fixed;
+    inset: 0;
+    z-index: -10;
+    pointer-events: none;
+    overflow: hidden;
+    background: radial-gradient(140% 120% at 50% -10%, hsl(252 40% 97%), hsl(var(--background)) 55%);
+  }
+  .dark .ambient-field {
+    background:
+      radial-gradient(120% 120% at 50% 0%, transparent 60%, hsl(0 0% 0% / 0.25)),
+      radial-gradient(140% 120% at 50% -10%, hsl(240 12% 14%), hsl(var(--background)) 60%);
+  }
+
+  .ambient-orb {
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(110px);
+    will-change: transform;
+  }
+
+  .ambient-grain {
+    position: absolute;
+    inset: 0;
+    opacity: var(--grain-opacity);
+    mix-blend-mode: soft-light;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+    background-size: 160px 160px;
+  }
+  .dark .ambient-grain { mix-blend-mode: overlay; }
+}
+
+/* ─── Canonical Liquid Glass material ─── */
+
+@layer components {
+  /* BASE PANE — the canonical material reused everywhere */
+  .glass {
+    position: relative;
+    background:
+      linear-gradient(135deg,
+        hsl(0 0% 100% / var(--glass-hi)) 0%,
+        hsl(0 0% 100% / calc(var(--glass-hi) * 0.35)) 40%,
+        hsl(0 0% 100% / 0) 100%),
+      hsl(var(--card) / var(--glass-fill));
+    -webkit-backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+    backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-sat));
+    border-radius: var(--radius);
+    box-shadow:
+      inset 0 1px 0 0 hsl(0 0% 100% / var(--glass-spec)),
+      inset 0 0 0 1px hsl(0 0% 100% / calc(var(--glass-spec) * 0.16)),
+      0 8px 24px -10px hsl(240 30% 12% / var(--glass-cast)),
+      0 2px 6px -2px hsl(240 30% 12% / calc(var(--glass-cast) * 0.7));
+  }
+
+  /* Directional lit bevel: bright top-left → dark bottom-right, one crisp masked ring */
+  .glass::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(135deg,
+      hsl(0 0% 100% / var(--glass-edge-hi)) 0%,
+      hsl(0 0% 100% / calc(var(--glass-edge-hi) * 0.15)) 42%,
+      hsl(240 30% 8% / var(--glass-edge-lo)) 100%);
+    -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+            mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
+    pointer-events: none;
+  }
+
+  /* STRONG — hero code card, contact cards, resume modal (combine: `glass glass-strong`) */
+  .glass-strong {
+    --glass-fill: calc(var(--glass-fill-base) + 0.10);
+    --glass-blur: var(--glass-blur-strong);
+    --glass-hi:   calc(var(--glass-hi-base) * 1.4);
+    --glass-spec: calc(var(--glass-spec-base) * 1.15);
+    --glass-cast: calc(var(--glass-cast-base) * 1.4);
+  }
+
+  /* THIN — chips, pills, icon keys, inputs. Cheap blur, no bevel, never deep-stacked */
+  .glass-thin {
+    position: relative;
+    background: hsl(var(--card) / calc(var(--glass-fill) * 0.8));
+    -webkit-backdrop-filter: blur(var(--glass-blur-thin)) saturate(140%);
+    backdrop-filter: blur(var(--glass-blur-thin)) saturate(140%);
+    border: 1px solid hsl(0 0% 100% / var(--glass-edge-hi));
+    border-radius: var(--radius);
+    box-shadow:
+      inset 0 1px 0 0 hsl(0 0% 100% / calc(var(--glass-spec) * 0.7)),
+      0 2px 8px -4px hsl(240 30% 12% / calc(var(--glass-cast) * 0.6));
+  }
+  .dark .glass-thin { border-color: hsl(0 0% 100% / calc(var(--glass-edge-hi) + 0.06)); }
+
+  /* SCRIM — alternating-section background, replaces bg-muted/30.
+     A flat translucent tint (no backdrop-filter): sections are huge, and the
+     cards inside already run their own blur — a section-wide filter would be a
+     costly nested pass for no visual gain over the fixed ambient field. */
+  .glass-scrim {
+    background: hsl(var(--card) / var(--scrim-fill));
+    border-top: 1px solid hsl(0 0% 100% / calc(var(--glass-edge-hi) * 0.6));
+    border-bottom: 1px solid hsl(240 30% 8% / calc(var(--glass-edge-lo) * 0.7));
+  }
+
+  /* HOVER LIFT — opt-in, compositor-only. Add next to `.glass` */
+  .glass-hover { transition: transform .3s ease, box-shadow .3s ease; }
+  .glass-hover:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      inset 0 1px 0 0 hsl(0 0% 100% / calc(var(--glass-spec) * 1.2)),
+      inset 0 0 0 1px hsl(0 0% 100% / calc(var(--glass-spec) * 0.16)),
+      0 16px 40px -14px hsl(var(--primary) / 0.28),
+      0 4px 10px -4px hsl(240 30% 12% / var(--glass-cast));
+  }
+}
+
 /* ─── Utility Classes ─── */
 
 @layer utilities {
@@ -127,6 +278,50 @@
   .cursor-blink {
     animation: typewriter-blink 1s step-end infinite;
   }
+
+  /* Signature interactive light — JS sets --mx/--my (see useGlassSheen). Add next to `.glass`. */
+  .glass-sheen::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity .25s ease;
+    mix-blend-mode: soft-light;
+    background: radial-gradient(200px circle at var(--mx, 50%) var(--my, 50%),
+      hsl(0 0% 100% / 0.18), transparent 60%);
+    /* Sit above the frosted fill but below card content (parent is a stacking
+       context via backdrop-filter), so the glow never tints text. */
+    z-index: -1;
+  }
+  .dark .glass-sheen::after {
+    mix-blend-mode: screen;
+    background: radial-gradient(200px circle at var(--mx, 50%) var(--my, 50%),
+      hsl(var(--primary) / 0.14), transparent 60%);
+  }
+  .glass-sheen[data-active="true"]::after { opacity: 1; }
+  @media (hover: none), (prefers-reduced-motion: reduce) {
+    .glass-sheen::after { display: none; }
+  }
+
+  /* Frosted form field — used by ui/input + ui/textarea */
+  .glass-input {
+    background: hsl(var(--card) / 0.6);
+    -webkit-backdrop-filter: blur(10px) saturate(140%);
+    backdrop-filter: blur(10px) saturate(140%);
+    border: 1px solid hsl(var(--border) / 0.7);
+  }
+  .glass-input:focus-visible { background: hsl(var(--card) / 0.92); }
+}
+
+/* ─── Graceful fallback: no backdrop-filter → near-opaque cards, layout intact ─── */
+@supports not ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .glass, .glass-thin { background: hsl(var(--card) / 0.94); }
+  .glass-scrim { background: hsl(var(--card) / 0.85); }
+  .glass-input { background: hsl(var(--card) / 0.92); }
+  .dark .glass, .dark .glass-thin { background: hsl(var(--card) / 0.92); }
+  .dark .glass-scrim { background: hsl(var(--card) / 0.8); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import "@/app/globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { ResumeModalProvider } from "@/components/resume-modal-provider"
+import AmbientField from "@/components/ambient-field"
 import { Inter, JetBrains_Mono } from "next/font/google"
 import type { Metadata } from "next"
 import { Analytics } from "@vercel/analytics/react"
@@ -72,6 +73,7 @@ export default function RootLayout({
       <head />
       <body className={`${inter.variable} ${jetbrainsMono.variable} font-sans`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
+          <AmbientField />
           <ResumeModalProvider>
             {children}
             <Analytics />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,7 +23,7 @@ export default function Home() {
       <ScrollProgress />
       <SectionViewTracker />
       <Navbar />
-      <main className="min-h-screen bg-background">
+      <main className="min-h-screen bg-transparent">
         <Hero />
         <About />
         <Experience />

--- a/components/about.tsx
+++ b/components/about.tsx
@@ -95,7 +95,7 @@ export default function About() {
   const statsInView = useInView(statsRef, { once: true, margin: "-100px" })
 
   return (
-    <section id="about" className="py-24 bg-muted/30">
+    <section id="about" className="py-24 glass-scrim">
       <div className="container mx-auto max-w-5xl px-4 md:px-8">
         <SectionHeading title="About Me" subtitle="Get to know me" />
 
@@ -126,7 +126,7 @@ export default function About() {
                 </div>
 
                 {/* Floating badge */}
-                <div className="absolute -bottom-4 -left-4 flex items-center gap-2 px-3 py-1.5 rounded-full bg-card border border-border shadow-lg text-xs font-mono z-10">
+                <div className="absolute -bottom-4 -left-4 flex items-center gap-2 px-3 py-1.5 rounded-full glass-thin text-xs font-mono z-10">
                   <span className="relative flex h-2 w-2">
                     <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-75" />
                     <span className="relative inline-flex rounded-full h-2 w-2 bg-accent" />
@@ -172,7 +172,7 @@ export default function About() {
         {/* Stats bar */}
         <div
           ref={statsRef}
-          className="grid grid-cols-2 md:grid-cols-4 gap-6 mt-20 py-10 px-6 border border-border rounded-2xl bg-card/50 shadow-sm"
+          className="grid grid-cols-2 md:grid-cols-4 gap-6 mt-20 py-10 px-6 rounded-2xl glass"
         >
           {stats.map((stat, index) => (
             <StatCard

--- a/components/ambient-field.tsx
+++ b/components/ambient-field.tsx
@@ -1,0 +1,52 @@
+/**
+ * AmbientField — the single liquid-glass refraction source.
+ *
+ * One fixed, full-viewport layer mounted once behind the entire document. It uses
+ * ZERO backdrop-filter (just painted gradients + drifting blurred orbs + static
+ * grain), so it costs one paint regardless of how far you scroll. Every `.glass`
+ * surface on the page refracts THIS. Brand hues only: lavender + mint, plus one
+ * tasteful periwinkle to keep the aurora from reading as "two blobs".
+ *
+ * Pure CSS animation → server component, no "use client". Drift freezes under
+ * prefers-reduced-motion via the global rule in globals.css.
+ */
+export default function AmbientField() {
+  return (
+    <div className="ambient-field" aria-hidden="true">
+      {/* Orb 1 — lavender, top-left */}
+      <div
+        className="ambient-orb animate-float-orb"
+        style={{
+          width: 640,
+          height: 640,
+          top: "-12%",
+          left: "-8%",
+          background: "rgb(var(--primary-rgb) / var(--orb-1))",
+        }}
+      />
+      {/* Orb 2 — mint, bottom-right */}
+      <div
+        className="ambient-orb animate-float-orb-2"
+        style={{
+          width: 540,
+          height: 540,
+          bottom: "-14%",
+          right: "-6%",
+          background: "rgb(var(--accent-rgb) / var(--orb-2))",
+        }}
+      />
+      {/* Orb 3 — periwinkle-indigo, center-right (the tasteful third hue) */}
+      <div
+        className="ambient-orb animate-float-orb-slow"
+        style={{
+          width: 380,
+          height: 380,
+          top: "42%",
+          right: "22%",
+          background: "hsl(266 70% 62% / var(--orb-3))",
+        }}
+      />
+      <div className="ambient-grain" />
+    </div>
+  )
+}

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -9,12 +9,14 @@ import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 import { Mail, Linkedin, Send, Loader2, ArrowUpRight } from "lucide-react"
-import { ease } from "@/lib/animations"
+import { ease, useGlassSheen } from "@/lib/animations"
 
 export default function Contact() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(false)
   const [isError, setIsError] = useState(false)
+  const emailRef = useGlassSheen<HTMLAnchorElement>()
+  const linkedinRef = useGlassSheen<HTMLAnchorElement>()
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -74,8 +76,9 @@ export default function Contact() {
             {/* Contact cards */}
             <div className="space-y-3">
               <a
+                ref={emailRef}
                 href="mailto:akshatsahu2634@gmail.com"
-                className="flex items-center gap-4 p-4 rounded-xl border border-border bg-card hover:border-primary/30 hover:bg-muted/50 transition-all duration-200 group"
+                className="glass glass-hover glass-sheen flex items-center gap-4 p-4 rounded-xl focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background group"
               >
                 <div className="p-2.5 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
                   <Mail className="h-4 w-4 text-primary" />
@@ -88,10 +91,11 @@ export default function Contact() {
               </a>
 
               <a
+                ref={linkedinRef}
                 href="https://linkedin.com/in/akshat2634"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center gap-4 p-4 rounded-xl border border-border bg-card hover:border-primary/30 hover:bg-muted/50 transition-all duration-200 group"
+                className="glass glass-hover glass-sheen flex items-center gap-4 p-4 rounded-xl focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background group"
               >
                 <div className="p-2.5 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
                   <Linkedin className="h-4 w-4 text-primary" />
@@ -105,7 +109,8 @@ export default function Contact() {
             </div>
 
             {/* Decorative quote card */}
-            <div className="mt-8 p-5 rounded-2xl bg-gradient-to-br from-primary/8 to-accent/8 border border-primary/10">
+            <div className="glass relative mt-8 p-5 rounded-2xl">
+              <div className="absolute inset-0 -z-10 rounded-2xl bg-gradient-to-br from-primary/8 to-accent/8" />
               <p className="text-[13px] text-muted-foreground font-mono leading-relaxed">
                 &ldquo;I&apos;m particularly interested in early-stage AI infrastructure, multi-agent systems, and founding engineering roles.&rdquo;
               </p>
@@ -132,7 +137,7 @@ export default function Contact() {
                   placeholder="Your name"
                   required
                   disabled={isSubmitting}
-                  className="bg-background border-border h-12 rounded-xl focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary transition-all duration-200 placeholder:text-muted-foreground/50"
+                  className="h-12 rounded-xl focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary transition-all duration-200 placeholder:text-muted-foreground"
                 />
               </div>
               <div className="space-y-1.5">
@@ -146,7 +151,7 @@ export default function Contact() {
                   placeholder="Your email"
                   required
                   disabled={isSubmitting}
-                  className="bg-background border-border h-12 rounded-xl focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary transition-all duration-200 placeholder:text-muted-foreground/50"
+                  className="h-12 rounded-xl focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary transition-all duration-200 placeholder:text-muted-foreground"
                 />
               </div>
             </div>
@@ -162,7 +167,7 @@ export default function Contact() {
                 rows={5}
                 required
                 disabled={isSubmitting}
-                className="bg-background border-border rounded-xl min-h-[140px] focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary transition-all duration-200 placeholder:text-muted-foreground/50"
+                className="rounded-xl min-h-[140px] focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:border-primary transition-all duration-200 placeholder:text-muted-foreground"
               />
             </div>
 

--- a/components/education.tsx
+++ b/components/education.tsx
@@ -3,7 +3,7 @@
 import { motion } from "motion/react"
 import SectionHeading from "./section-heading"
 import { GraduationCap, Calendar, MapPin, Star } from "lucide-react"
-import { staggerContainer, staggerItem } from "@/lib/animations"
+import { staggerContainer, useGlassReveal } from "@/lib/animations"
 
 const degreeConfig: Record<string, {
   gradient: string
@@ -23,6 +23,7 @@ const degreeConfig: Record<string, {
 }
 
 export default function Education() {
+  const reveal = useGlassReveal()
   const educationData = [
     {
       institution: "Stevens Institute of Technology",
@@ -43,7 +44,7 @@ export default function Education() {
   ]
 
   return (
-    <section id="education" className="py-24 bg-muted/30">
+    <section id="education" className="py-24 glass-scrim">
       <div className="container mx-auto max-w-5xl px-4 md:px-8">
         <SectionHeading title="Education" subtitle="Academic background" />
 
@@ -57,8 +58,8 @@ export default function Education() {
           {educationData.map((edu, index) => {
             const config = degreeConfig[edu.degree]
             return (
-              <motion.div key={index} variants={staggerItem}>
-                <div className="border border-border rounded-xl overflow-hidden bg-card hover:border-primary/20 transition-colors duration-200 group">
+              <motion.div key={index} variants={reveal}>
+                <div className="glass glass-hover rounded-xl overflow-hidden group">
                   {/* Top gradient bar */}
                   <div className={`h-1 bg-gradient-to-r ${config.gradient}`} />
 

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -3,7 +3,7 @@
 import { motion } from "motion/react"
 import SectionHeading from "./section-heading"
 import { Calendar, MapPin, ChevronRight } from "lucide-react"
-import { staggerContainer, staggerItem } from "@/lib/animations"
+import { staggerContainer, useGlassReveal } from "@/lib/animations"
 
 const coreSkills = new Set([
   "RAG", "Hybrid Search", "Cross-Encoder Reranking", "LangGraph", "DeepAgents",
@@ -11,6 +11,7 @@ const coreSkills = new Set([
 ])
 
 export default function Experience() {
+  const reveal = useGlassReveal()
   const experiences = [
     {
       title: "Founding Software Engineer",
@@ -59,7 +60,7 @@ export default function Experience() {
           {experiences.map((exp, index) => (
             <motion.div
               key={index}
-              variants={staggerItem}
+              variants={reveal}
               className="grid grid-cols-1 md:grid-cols-[auto_1fr] gap-0 md:gap-6"
             >
               {/* Left rail: dot + connecting line */}
@@ -76,7 +77,7 @@ export default function Experience() {
               </div>
 
               {/* Card */}
-              <div className="mb-8 relative border border-border rounded-xl overflow-hidden bg-card hover:border-primary/30 hover:shadow-md hover:shadow-primary/5 transition-all duration-300 group">
+              <div className="mb-8 relative glass glass-hover rounded-xl overflow-hidden transition-all duration-300 group">
                 {/* Left edge accent bar */}
                 <div className={`absolute left-0 top-0 bottom-0 w-1 ${index === 0 ? "bg-gradient-to-b from-primary to-accent" : "bg-primary/30"}`} />
 
@@ -131,7 +132,7 @@ export default function Experience() {
                         className={`px-2.5 py-1 rounded-md text-[11px] font-mono font-medium tracking-wide uppercase cursor-default transition-colors
                           ${coreSkills.has(skill)
                             ? "bg-primary/10 text-primary border border-primary/20"
-                            : "bg-muted text-muted-foreground hover:bg-primary/10 hover:text-primary"
+                            : "glass-thin text-foreground/80 hover:bg-primary/10 hover:text-primary"
                           }`}
                       >
                         {skill}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -4,7 +4,7 @@ export default function Footer() {
   const currentYear = new Date().getFullYear()
 
   return (
-    <footer className="border-t border-border bg-muted/20">
+    <footer className="glass-scrim">
       <div className="container mx-auto max-w-5xl px-4 py-10">
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-6">
           {/* Brand */}
@@ -21,7 +21,7 @@ export default function Footer() {
               <a
                 key={link}
                 href={`#${link.toLowerCase()}`}
-                className="text-[13px] text-muted-foreground hover:text-primary transition-colors duration-200"
+                className="text-[13px] text-muted-foreground hover:text-primary transition-colors duration-200 rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
                 {link}
               </a>
@@ -41,7 +41,7 @@ export default function Footer() {
                 aria-label={label}
                 target={external ? "_blank" : undefined}
                 rel={external ? "noopener noreferrer" : undefined}
-                className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-all duration-200"
+                className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-primary/10 transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
               >
                 <Icon className="h-4 w-4" />
               </a>

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { motion } from "motion/react"
 import { FileText, Github, Linkedin, Mail } from "lucide-react"
 import Link from "next/link"
-import { ease } from "@/lib/animations"
+import { ease, useGlassSheen } from "@/lib/animations"
 import { useState, useEffect } from "react"
 import { useResumeModal } from "./resume-modal-provider"
 
@@ -59,13 +59,11 @@ function useTypewriter(words: string[], typingSpeed = 75, deletingSpeed = 45, pa
 export default function Hero() {
   const { displayed: roleText, enabled: typewriterEnabled } = useTypewriter(roles)
   const { open: openResume, prefetch: prefetchResume } = useResumeModal()
+  const cardRef = useGlassSheen<HTMLDivElement>()
 
   return (
     <section id="home" className="relative min-h-screen flex items-center justify-center overflow-hidden">
-      {/* Floating orbs */}
-      <div className="absolute -top-40 -left-32 w-[580px] h-[580px] rounded-full bg-primary/10 blur-[110px] animate-float-orb pointer-events-none" />
-      <div className="absolute -bottom-40 -right-20 w-[480px] h-[480px] rounded-full bg-accent/[0.08] blur-[100px] animate-float-orb-2 pointer-events-none" />
-      <div className="absolute top-1/2 right-1/4 w-[280px] h-[280px] rounded-full bg-primary/[0.06] blur-[80px] animate-float-orb-slow pointer-events-none" />
+      {/* Floating aurora orbs now live globally in <AmbientField /> so every section refracts the same light. */}
 
       {/* Dot grid */}
       <div className="absolute inset-0 bg-[radial-gradient(hsl(var(--border))_1px,transparent_1px)] [background-size:26px_26px] opacity-35 pointer-events-none" />
@@ -82,7 +80,7 @@ export default function Hero() {
               transition={{ duration: 0.5, delay: 0.1, ease }}
               className="flex justify-center xl:justify-start"
             >
-              <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full bg-primary/10 text-primary text-xs font-mono font-medium tracking-wide border border-primary/20">
+              <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full glass-thin text-primary text-xs font-mono font-medium tracking-wide">
                 <span className="relative flex h-2 w-2">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent opacity-75" />
                   <span className="relative inline-flex rounded-full h-2 w-2 bg-accent" />
@@ -134,19 +132,19 @@ export default function Hero() {
               transition={{ duration: 0.6, delay: 0.55, ease }}
             >
               <Link href="https://github.com/akshat2634" target="_blank" rel="noopener noreferrer">
-                <Button variant="outline" size="icon" className="h-10 w-10 rounded-xl border-border hover:border-primary/40 hover:bg-primary/5 hover:scale-105 transition-all duration-200">
+                <Button variant="glass" size="icon" className="h-10 w-10 rounded-xl">
                   <Github className="h-4 w-4" />
                 </Button>
               </Link>
 
               <Link href="https://linkedin.com/in/akshat2634" target="_blank" rel="noopener noreferrer">
-                <Button variant="outline" size="icon" className="h-10 w-10 rounded-xl border-border hover:border-primary/40 hover:bg-primary/5 hover:scale-105 transition-all duration-200">
+                <Button variant="glass" size="icon" className="h-10 w-10 rounded-xl">
                   <Linkedin className="h-4 w-4" />
                 </Button>
               </Link>
 
               <Link href="mailto:akshatsahu2634@gmail.com">
-                <Button variant="outline" size="icon" className="h-10 w-10 rounded-xl border-border hover:border-primary/40 hover:bg-primary/5 hover:scale-105 transition-all duration-200">
+                <Button variant="glass" size="icon" className="h-10 w-10 rounded-xl">
                   <Mail className="h-4 w-4" />
                 </Button>
               </Link>
@@ -172,7 +170,7 @@ export default function Hero() {
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.7, delay: 0.4, ease }}
           >
-            <div className="relative w-64 rounded-2xl border border-border/70 bg-card/70 backdrop-blur-md p-5 shadow-2xl shadow-primary/[0.08]">
+            <div ref={cardRef} className="glass glass-strong glass-sheen relative w-64 rounded-2xl p-5">
               {/* Window chrome */}
               <div className="flex items-center gap-1.5 mb-5">
                 <div className="w-3 h-3 rounded-full bg-red-400/70" />

--- a/components/mode-toggle.tsx
+++ b/components/mode-toggle.tsx
@@ -25,7 +25,7 @@ export function ModeToggle() {
       variant="ghost"
       size="icon"
       onClick={cycleTheme}
-      className="h-9 w-9 rounded-lg"
+      className="h-9 w-9 rounded-lg hover:bg-primary/10"
       aria-label="Toggle theme"
     >
       {theme === "light" && <Sun className="h-4 w-4" />}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -84,9 +84,9 @@ export default function Navbar() {
           motion owns BOTH x and y so its inline transform doesn't wipe Tailwind's centering. */}
       <motion.header
         className={cn(
-          "fixed top-4 left-1/2 z-50 transition-all duration-300 hidden lg:block max-w-[calc(100vw-2rem)]",
+          "fixed top-4 left-1/2 z-50 transition-[background-color,box-shadow] duration-300 hidden lg:block max-w-[calc(100vw-2rem)]",
           isScrolled
-            ? "bg-background/80 backdrop-blur-xl border border-border shadow-md shadow-primary/5 rounded-full px-2 py-1.5"
+            ? "glass glass-strong rounded-full px-2 py-1.5"
             : "bg-transparent px-2 py-1.5"
         )}
         initial={{ x: "-50%", y: -20, opacity: 0 }}
@@ -97,7 +97,7 @@ export default function Navbar() {
           <Link
             href="#home"
             onClick={(e) => handleNavClick(e, "#home")}
-            className="text-sm font-bold gradient-text px-3 py-1.5"
+            className="text-sm font-bold gradient-text px-3 py-1.5 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
           >
             AS
           </Link>
@@ -112,10 +112,10 @@ export default function Navbar() {
                 href={link.href}
                 onClick={(e) => handleNavClick(e, link.href)}
                 className={cn(
-                  "px-3 py-1.5 text-[13px] font-medium rounded-full transition-colors duration-200",
+                  "px-3 py-1.5 text-[13px] font-medium rounded-full transition-colors duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                   isActive
                     ? "bg-gradient-to-r from-primary/15 to-accent/10 text-primary font-semibold"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
+                    : "text-muted-foreground hover:text-foreground hover:bg-primary/10"
                 )}
               >
                 {link.name}
@@ -143,9 +143,9 @@ export default function Navbar() {
       {/* Mobile + tablet nav (below lg) */}
       <motion.header
         className={cn(
-          "fixed top-0 left-0 right-0 z-50 lg:hidden transition-all duration-300",
+          "fixed top-0 left-0 right-0 z-50 lg:hidden transition-[background-color,box-shadow] duration-300",
           isScrolled
-            ? "bg-background/80 backdrop-blur-xl border-b border-border"
+            ? "glass glass-strong rounded-none"
             : "bg-transparent"
         )}
         initial={{ y: -20, opacity: 0 }}
@@ -182,14 +182,14 @@ export default function Navbar() {
               animate={{ opacity: 1, height: "auto" }}
               exit={{ opacity: 0, height: 0 }}
               transition={{ duration: 0.2 }}
-              className="bg-background border-b border-border"
+              className="glass glass-strong rounded-none"
             >
               <div className="px-4 py-2">
                 {navLinks.map((link) => (
                   <Link
                     key={link.name}
                     href={link.href}
-                    className="block py-2.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                    className="block py-2.5 px-2 rounded-md text-sm text-muted-foreground hover:text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                     onClick={(e) => handleNavClick(e, link.href)}
                   >
                     {link.name}

--- a/components/projects.tsx
+++ b/components/projects.tsx
@@ -7,7 +7,7 @@ import SectionHeading from "./section-heading"
 import { Button } from "@/components/ui/button"
 import { ExternalLink, Github, ArrowRight, Copy, Check, Terminal } from "lucide-react"
 import Link from "next/link"
-import { staggerContainer, staggerItem } from "@/lib/animations"
+import { staggerContainer, useGlassReveal, useGlassSheen } from "@/lib/animations"
 
 const techColors: Record<string, string> = {
   "FastAPI":              "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
@@ -86,7 +86,115 @@ function CliBlock() {
   )
 }
 
+type Project = {
+  title: string
+  tagline: string | undefined
+  cliCommand: string | undefined
+  period: string
+  description: string
+  features: string[]
+  technologies: string[]
+  github: string | null
+  demo: string | null
+  color: string
+  accentColor: string
+  borderColor: string
+  bulletColor: string
+}
+
+function ProjectCard({ project, index }: { project: Project; index: number }) {
+  const ref = useGlassSheen<HTMLDivElement>()
+
+  return (
+    <div ref={ref} className={`glass glass-hover glass-sheen border ${project.borderColor} rounded-2xl overflow-hidden group`}>
+
+      {/* Gradient header */}
+      <div className={`px-6 pt-6 pb-5 bg-gradient-to-br ${project.color}`}>
+        <div className="flex items-start justify-between">
+          <div>
+            <p className={`text-[10px] font-mono tracking-widest uppercase mb-2 ${project.accentColor} opacity-60`}>
+              Project 0{index + 1}
+            </p>
+            <div className="flex items-center gap-2.5">
+              <h3 className="text-xl font-bold tracking-tight text-foreground">{project.title}</h3>
+              {project.demo && (
+                <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent/15 text-accent text-[10px] font-mono tracking-wider border border-accent/20">
+                  <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse" />
+                  Live
+                </span>
+              )}
+            </div>
+            {project.tagline && (
+              <p className={`text-[11px] font-mono mt-1 ${project.accentColor} opacity-70`}>
+                {project.tagline}
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground font-mono mt-1">{project.period}</p>
+          </div>
+
+          <div className="flex gap-2">
+            {project.github && (
+              <Link
+                href={project.github}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => track("project_github_click", { project: project.title })}
+              >
+                <Button variant="glass" size="icon" className="h-9 w-9 rounded-xl">
+                  <Github className="h-4 w-4" />
+                </Button>
+              </Link>
+            )}
+            {project.demo && (
+              <Link
+                href={project.demo}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => track("project_demo_click", { project: project.title })}
+              >
+                <Button size="icon" className="h-9 w-9 rounded-xl bg-primary/10 text-primary hover:bg-primary/20 border-0 shadow-none">
+                  <ExternalLink className="h-4 w-4" />
+                </Button>
+              </Link>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="p-6">
+        {project.cliCommand && <CliBlock />}
+
+        <p className="text-[15px] text-muted-foreground leading-relaxed mb-5">{project.description}</p>
+
+        <div className="space-y-3 mb-6">
+          {project.features.map((feature, idx) => (
+            <div key={idx} className="flex gap-3">
+              <div className={`mt-0.5 shrink-0 w-5 h-5 rounded-md flex items-center justify-center ${project.bulletColor}`}>
+                <ArrowRight className="h-3 w-3" />
+              </div>
+              <p className="text-[14px] text-muted-foreground leading-relaxed">{feature}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap gap-1.5">
+          {project.technologies.map((tech) => (
+            <span
+              key={tech}
+              className={`px-2.5 py-1 rounded-lg text-[11px] font-mono font-medium border ${techColors[tech] ?? "bg-muted text-muted-foreground border-border"}`}
+            >
+              {tech}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function Projects() {
+  const reveal = useGlassReveal()
   const projects = [
     {
       title: "CodeLens AI",
@@ -172,7 +280,7 @@ export default function Projects() {
   ]
 
   return (
-    <section id="projects" className="py-24 bg-muted/30">
+    <section id="projects" className="py-24 glass-scrim">
       <div className="container mx-auto max-w-5xl px-4 md:px-8">
         <SectionHeading title="Projects" subtitle="Recent work" />
 
@@ -184,91 +292,8 @@ export default function Projects() {
           viewport={{ once: true, margin: "-80px" }}
         >
           {projects.map((project, index) => (
-            <motion.div key={index} variants={staggerItem}>
-              <div className={`border ${project.borderColor} rounded-2xl overflow-hidden bg-card group hover:shadow-lg hover:shadow-primary/5 transition-all duration-300`}>
-
-                {/* Gradient header */}
-                <div className={`px-6 pt-6 pb-5 bg-gradient-to-br ${project.color}`}>
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <p className={`text-[10px] font-mono tracking-widest uppercase mb-2 ${project.accentColor} opacity-60`}>
-                        Project 0{index + 1}
-                      </p>
-                      <div className="flex items-center gap-2.5">
-                        <h3 className="text-xl font-bold tracking-tight text-foreground">{project.title}</h3>
-                        {project.demo && (
-                          <span className="flex items-center gap-1 px-2 py-0.5 rounded-full bg-accent/15 text-accent text-[10px] font-mono tracking-wider border border-accent/20">
-                            <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse" />
-                            Live
-                          </span>
-                        )}
-                      </div>
-                      {project.tagline && (
-                        <p className={`text-[11px] font-mono mt-1 ${project.accentColor} opacity-70`}>
-                          {project.tagline}
-                        </p>
-                      )}
-                      <p className="text-xs text-muted-foreground font-mono mt-1">{project.period}</p>
-                    </div>
-
-                    <div className="flex gap-2">
-                      {project.github && (
-                        <Link
-                          href={project.github}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={() => track("project_github_click", { project: project.title })}
-                        >
-                          <Button variant="outline" size="icon" className="h-9 w-9 rounded-xl border-border hover:border-primary/30 hover:bg-primary/5">
-                            <Github className="h-4 w-4" />
-                          </Button>
-                        </Link>
-                      )}
-                      {project.demo && (
-                        <Link
-                          href={project.demo}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={() => track("project_demo_click", { project: project.title })}
-                        >
-                          <Button size="icon" className="h-9 w-9 rounded-xl bg-primary/10 text-primary hover:bg-primary/20 border-0 shadow-none">
-                            <ExternalLink className="h-4 w-4" />
-                          </Button>
-                        </Link>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {/* Body */}
-                <div className="p-6">
-                  {project.cliCommand && <CliBlock />}
-
-                  <p className="text-[15px] text-muted-foreground leading-relaxed mb-5">{project.description}</p>
-
-                  <div className="space-y-3 mb-6">
-                    {project.features.map((feature, idx) => (
-                      <div key={idx} className="flex gap-3">
-                        <div className={`mt-0.5 shrink-0 w-5 h-5 rounded-md flex items-center justify-center ${project.bulletColor}`}>
-                          <ArrowRight className="h-3 w-3" />
-                        </div>
-                        <p className="text-[14px] text-muted-foreground leading-relaxed">{feature}</p>
-                      </div>
-                    ))}
-                  </div>
-
-                  <div className="flex flex-wrap gap-1.5">
-                    {project.technologies.map((tech) => (
-                      <span
-                        key={tech}
-                        className={`px-2.5 py-1 rounded-lg text-[11px] font-mono font-medium border ${techColors[tech] ?? "bg-muted text-muted-foreground border-border"}`}
-                      >
-                        {tech}
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              </div>
+            <motion.div key={index} variants={reveal}>
+              <ProjectCard project={project} index={index} />
             </motion.div>
           ))}
         </motion.div>

--- a/components/resume-modal.tsx
+++ b/components/resume-modal.tsx
@@ -23,7 +23,7 @@ export default function ResumeModal({
           <Dialog.Portal forceMount>
             <Dialog.Overlay asChild forceMount>
               <motion.div
-                className="fixed inset-0 z-[100] bg-background/80 backdrop-blur-md"
+                className="fixed inset-0 z-[100] bg-background/80 backdrop-blur-xl"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
@@ -40,7 +40,7 @@ export default function ResumeModal({
                 transition={{ duration: 0.2, ease }}
               >
                 <motion.div
-                  className="relative w-full max-w-5xl h-[92vh] flex flex-col rounded-2xl border border-border bg-card shadow-2xl shadow-primary/10 overflow-hidden"
+                  className="relative w-full max-w-5xl h-[92vh] flex flex-col rounded-2xl glass glass-strong shadow-2xl shadow-primary/10 overflow-hidden"
                   initial={{ opacity: 0, scale: 0.96, y: 12 }}
                   animate={{ opacity: 1, scale: 1, y: 0 }}
                   exit={{ opacity: 0, scale: 0.97, y: 8 }}
@@ -50,7 +50,7 @@ export default function ResumeModal({
                   <div className="h-1 bg-gradient-to-r from-primary via-accent to-primary shrink-0" />
 
                   {/* Header */}
-                  <div className="flex items-center justify-between gap-3 px-4 sm:px-5 py-3 border-b border-border bg-card/95 backdrop-blur-sm shrink-0">
+                  <div className="flex items-center justify-between gap-3 px-4 sm:px-5 py-3 glass-thin shrink-0">
                     <div className="flex items-center gap-2.5 min-w-0">
                       <div className="p-2 rounded-lg bg-primary/10 shrink-0">
                         <FileText className="h-4 w-4 text-primary" />

--- a/components/scroll-progress.tsx
+++ b/components/scroll-progress.tsx
@@ -36,7 +36,7 @@ export default function ScrollProgress() {
   return (
     <div className="fixed top-0 left-0 w-full h-0.5 z-[60]">
       <div
-        className="h-full bg-primary transition-all duration-150 ease-out"
+        className="h-full bg-gradient-to-r from-primary to-accent transition-all duration-150 ease-out"
         style={{ width: `${scrollProgress}%` }}
       />
     </div>

--- a/components/scroll-to-top.tsx
+++ b/components/scroll-to-top.tsx
@@ -34,8 +34,8 @@ export function ScrollToTop() {
           <Button
             onClick={scrollToTop}
             size="icon"
-            variant="outline"
-            className="h-9 w-9 rounded-lg bg-card border-border hover:bg-muted"
+            variant="glass"
+            className="h-9 w-9 rounded-full"
             aria-label="Scroll to top"
           >
             <ArrowUp className="h-4 w-4" />

--- a/components/skills.tsx
+++ b/components/skills.tsx
@@ -139,10 +139,10 @@ export default function Skills() {
               <button
                 key={idx}
                 onClick={() => setActiveCategory(idx)}
-                className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200
+                className={`flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background
                   ${isActive
                     ? "bg-primary text-primary-foreground shadow-md shadow-primary/20"
-                    : "bg-muted text-muted-foreground hover:text-foreground hover:bg-muted/80"
+                    : "glass-thin text-muted-foreground hover:text-foreground"
                   }`}
               >
                 <Icon className="h-3.5 w-3.5" />
@@ -160,8 +160,13 @@ export default function Skills() {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -10 }}
             transition={{ duration: 0.25, ease }}
-            className={`p-8 rounded-2xl border border-border bg-gradient-to-br ${active.color}`}
+            className="glass relative p-8 rounded-2xl"
           >
+            {/* Per-category tint overlay (frost + tint coexist) */}
+            <div
+              className={`absolute inset-0 -z-10 rounded-2xl bg-gradient-to-br ${active.color} opacity-40 pointer-events-none`}
+            />
+
             {/* Category header */}
             <div className="flex items-center gap-3 mb-6">
               <div className={`p-3 rounded-xl ${active.iconColor}`}>
@@ -180,10 +185,10 @@ export default function Skills() {
               {active.skills.map((skill) => (
                 <span
                   key={skill.name}
-                  className={`px-3 py-1.5 rounded-xl text-[13px] font-medium transition-all duration-200 border
+                  className={`px-3 py-1.5 rounded-xl text-[13px] font-medium transition-all duration-200
                     ${skill.core
-                      ? "bg-primary/15 text-primary border-primary/25 font-semibold"
-                      : "bg-background/60 text-muted-foreground border-border"
+                      ? "bg-primary/15 text-primary border border-primary/25 font-semibold"
+                      : "glass-thin text-foreground/80"
                     }`}
                 >
                   {skill.name}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -18,6 +18,7 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-muted hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        glass: "glass-thin glass-hover text-foreground hover:brightness-110 hover:text-primary",
       },
       size: {
         default: "h-10 px-4 py-2",

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "glass-input flex h-10 w-full rounded-md px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           className
         )}
         ref={ref}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-md glass-input px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className
       )}
       ref={ref}

--- a/lib/animations.ts
+++ b/lib/animations.ts
@@ -1,3 +1,6 @@
+import { useEffect, useRef } from "react"
+import { useReducedMotion } from "motion/react"
+
 export const ease = [0.25, 0.46, 0.45, 0.94] as const
 
 export const fadeInUp = {
@@ -22,4 +25,105 @@ export const staggerItem = {
     y: 0,
     transition: { duration: 0.4, ease },
   },
+}
+
+/**
+ * glassReveal — the liquid-glass entrance: each pane "focuses into" existence,
+ * fading + rising while a soft blur resolves to sharp, like a lens settling.
+ * Use on card grids in place of staggerItem (pair with staggerContainer).
+ */
+export const glassReveal = {
+  hidden: { opacity: 0, y: 16, filter: "blur(8px)" },
+  visible: {
+    opacity: 1,
+    y: 0,
+    filter: "blur(0px)",
+    transition: { duration: 0.55, ease },
+  },
+}
+
+/**
+ * Reduced-motion-aware glassReveal. framer-motion animations are JS-driven and
+ * are NOT stopped by the global prefers-reduced-motion CSS rule, so we gate the
+ * blur/travel here: reduced-motion users get a plain, quick opacity fade.
+ */
+export function useGlassReveal() {
+  const reduce = useReducedMotion()
+  if (reduce) {
+    return {
+      hidden: { opacity: 0 },
+      visible: { opacity: 1, transition: { duration: 0.2 } },
+    }
+  }
+  return glassReveal
+}
+
+/**
+ * useGlassSheen — the signature interactive light. Attach the returned ref to a
+ * `.glass-sheen` element; a soft specular glow tracks the pointer across it.
+ *
+ * Hard guards (per the design spec): bails entirely on touch (pointer: coarse)
+ * and on prefers-reduced-motion; binds pointermove ONLY while hovered; rAF-
+ * throttled; writes only the --mx/--my CSS vars (no React re-render, no layout
+ * thrash beyond one cached rect per hover). Cap usage to ≤6 elements site-wide.
+ */
+export function useGlassSheen<T extends HTMLElement = HTMLDivElement>() {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof window === "undefined" || !window.matchMedia) return
+    if (
+      window.matchMedia("(pointer: coarse)").matches ||
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches
+    ) {
+      return
+    }
+
+    let rect: DOMRect | null = null
+    let raf = 0
+    let nextX = 50
+    let nextY = 50
+
+    const apply = () => {
+      raf = 0
+      el.style.setProperty("--mx", `${nextX}%`)
+      el.style.setProperty("--my", `${nextY}%`)
+    }
+
+    const onMove = (e: PointerEvent) => {
+      if (!rect) rect = el.getBoundingClientRect()
+      nextX = ((e.clientX - rect.left) / rect.width) * 100
+      nextY = ((e.clientY - rect.top) / rect.height) * 100
+      if (!raf) raf = requestAnimationFrame(apply)
+    }
+
+    const onEnter = () => {
+      rect = el.getBoundingClientRect()
+      el.dataset.active = "true"
+      el.addEventListener("pointermove", onMove)
+    }
+
+    const onLeave = () => {
+      el.removeEventListener("pointermove", onMove)
+      el.dataset.active = "false"
+      rect = null
+      if (raf) {
+        cancelAnimationFrame(raf)
+        raf = 0
+      }
+    }
+
+    el.addEventListener("pointerenter", onEnter)
+    el.addEventListener("pointerleave", onLeave)
+
+    return () => {
+      el.removeEventListener("pointerenter", onEnter)
+      el.removeEventListener("pointerleave", onLeave)
+      el.removeEventListener("pointermove", onMove)
+      if (raf) cancelAnimationFrame(raf)
+    }
+  }, [])
+
+  return ref
 }


### PR DESCRIPTION
## Summary

Reimagines the portfolio's material language as Apple-style **liquid glass**, while preserving the lavender/mint brand palette and both light & dark themes. Only the surface *material* changed — the design system, content, and layout are intact.

## What's inside

**Foundation** ([app/globals.css](app/globals.css))
- Token-driven glass material; `.dark` overrides only the `-base` vars so light/dark read as one material under different light.
- A single fixed **ambient aurora field** (zero `backdrop-filter`) as the shared refraction source for every glass surface: painted gradients, 3 drifting blurred orbs, SVG grain.
- Three glass tiers — `.glass`/`.glass-strong` (cards), `.glass-thin` (chips, pills, tabs, icon buttons), `.glass-scrim` (section backplates, no blur).
- Masked gradient-border bevel + specular insets + float shadows.

**Interaction & motion** ([lib/animations.ts](lib/animations.ts))
- `useGlassSheen` — rAF pointer-tracked specular highlight via `--mx`/`--my`, capped at ≤6 elements, disabled on touch + reduced-motion.
- `useGlassReveal` — gates the JS blur/travel entrance under `prefers-reduced-motion` (CSS alone can't stop framer-motion).
- New `glass` button variant.

**Hardening**
- Opaque anchors kept readable (resume CTA, terminal mock, active tabs, core-skill badges). `focus-visible` rings throughout. Contrast bumps on non-core chips and form placeholders.
- Perf: no `backdrop-filter` on the ambient field/scrims, no glass-on-glass stacking, `will-change` scoped to the 3 orbs only.
- `@supports not (backdrop-filter)` fallback renders near-opaque cards.

## Verification
- `tsc --noEmit` clean
- `next build` green (6/6 static pages)
- Visually verified light + dark across every section (hero, about, experience, education, skills, projects, contact, navbar, footer, resume modal)

## Files
21 files changed (+533 / −144), incl. new `components/ambient-field.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)